### PR TITLE
feat: workflow and job example for GHA actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,21 @@ orbs:
   node: circleci/node@5.1.0
 
 jobs:
+  show-gha-vars:
+    docker:
+      - image: node:20-alpine
+    steps:
+      - run:
+          name: List GHA parameters
+          command: |
+            echo "GHA_Actor is << pipeline.parameters.GHA_Actor >>"
+            echo "GHA_Action is << pipeline.parameters.GHA_Action >>"
+            echo "GHA_Event is << pipeline.parameters.GHA_Event >>"
+            echo "GHA_Meta is << pipeline.parameters.GHA_Meta >>"
+            echo "CIRCLE_PULL_REQUEST: $CIRCLE_PULL_REQUEST"
+            echo "CIRCLE_BRANCH: $CIRCLE_BRANCH"
+            echo "pipeline.git.branch: $pipeline.git.branch"
+
   build:
     # Build job configuration
     docker:
@@ -92,6 +107,17 @@ workflows:
   # Inside the workflow, you provide the jobs you want to run, e.g this workflow runs the build-and-test job above.
   # CircleCI will run this workflow on every commit.
   # For more details on extending your workflow, see the configuration docs: https://circleci.com/docs/configuration-reference/#workflows
+  show:
+    when: << pipeline.parameters.GHA_Action >>
+    jobs:
+      - show-gha-vars
+  show-two:
+    when:
+      or:
+        - equal: [pull_request, << pipeline.parameters.GHA_Event >>]
+        - equal: [release, << pipeline.parameters.GHA_Event >>]
+    jobs:
+      - show-gha-vars
   build_and_test:
     when:
       or:


### PR DESCRIPTION
Added 'show-vars' Example in config.yml to Investigate Deploy Job Issue

Details:
In this pull request, we have added a new example in the 'config.yml' file in order to investigate the issue we are experiencing with the 'deploy-to-vercel' job. A new job called 'show-gha-vars' has been created, which displays the values of relevant environment variables, including 'CIRCLE_PULL_REQUEST', 'CIRCLE_BRANCH', and 'pipeline.git.branch', in the CircleCI logs output.