### PR TITLE
fix: add ProjectsModule to main (PR #28 landed on wrong base)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TasksModule } from './tasks/tasks.module';
 import { UsersModule } from './users/users.module';
+import { ProjectsModule } from './projects/projects.module';
 import { ConfigModule } from '@nestjs/config';
 import { PrismaModule } from './prisma/prisma.module';
 
@@ -16,6 +17,7 @@ import { PrismaModule } from './prisma/prisma.module';
     // Feature modules
     TasksModule,
     UsersModule,
+    ProjectsModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/dto/create-project.dto.ts
+++ b/apps/api/src/dto/create-project.dto.ts
@@ -1,0 +1,10 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class CreateProjectDto {
+  @IsString()
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+}

--- a/apps/api/src/dto/update-project.dto.ts
+++ b/apps/api/src/dto/update-project.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateProjectDto } from './create-project.dto';
+
+export class UpdateProjectDto extends PartialType(CreateProjectDto) {}

--- a/apps/api/src/projects/projects.controller.ts
+++ b/apps/api/src/projects/projects.controller.ts
@@ -1,0 +1,74 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  HttpCode,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ProjectsService } from './projects.service';
+import { CreateProjectDto } from '../dto/create-project.dto';
+import { UpdateProjectDto } from '../dto/update-project.dto';
+
+@ApiTags('projects')
+@Controller('projects')
+export class ProjectsController {
+  constructor(private readonly projectsService: ProjectsService) {}
+
+  /**
+   * Retrieve all projects
+   */
+  @ApiOperation({ summary: 'Get all projects' })
+  @ApiResponse({ status: 200, description: 'Returns an array of projects' })
+  @Get()
+  findAll() {
+    return this.projectsService.findAll();
+  }
+
+  /**
+   * Retrieve a single project by ID
+   */
+  @ApiOperation({ summary: 'Get a project by ID' })
+  @ApiResponse({ status: 200, description: 'Returns the project' })
+  @ApiResponse({ status: 404, description: 'Project not found' })
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.projectsService.findOne(id);
+  }
+
+  /**
+   * Create a new project
+   */
+  @ApiOperation({ summary: 'Create a new project' })
+  @ApiResponse({ status: 201, description: 'Returns the created project' })
+  @Post()
+  create(@Body() body: CreateProjectDto) {
+    return this.projectsService.create(body);
+  }
+
+  /**
+   * Update a project by ID
+   */
+  @ApiOperation({ summary: 'Update a project by ID' })
+  @ApiResponse({ status: 200, description: 'Returns the updated project' })
+  @ApiResponse({ status: 404, description: 'Project not found' })
+  @Put(':id')
+  update(@Param('id') id: string, @Body() body: UpdateProjectDto) {
+    return this.projectsService.update(id, body);
+  }
+
+  /**
+   * Delete a project by ID
+   */
+  @ApiOperation({ summary: 'Delete a project by ID' })
+  @ApiResponse({ status: 204, description: 'Project deleted' })
+  @ApiResponse({ status: 404, description: 'Project not found' })
+  @Delete(':id')
+  @HttpCode(204)
+  remove(@Param('id') id: string) {
+    return this.projectsService.remove(id);
+  }
+}

--- a/apps/api/src/projects/projects.module.ts
+++ b/apps/api/src/projects/projects.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ProjectsController } from './projects.controller';
+import { ProjectsService } from './projects.service';
+
+@Module({
+  controllers: [ProjectsController],
+  providers: [ProjectsService],
+})
+export class ProjectsModule {}

--- a/apps/api/src/projects/projects.service.spec.ts
+++ b/apps/api/src/projects/projects.service.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * Test suite: ProjectsService
+ *
+ * Unit tests using a mocked PrismaService.
+ * No database connection required.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { ProjectsService } from './projects.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { Prisma } from '@prisma/client';
+
+const mockPrismaProject = {
+  create: jest.fn(),
+  findMany: jest.fn(),
+  findUnique: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+};
+
+const mockPrismaService = {
+  project: mockPrismaProject,
+};
+
+describe('ProjectsService', () => {
+  let service: ProjectsService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProjectsService,
+        { provide: PrismaService, useValue: mockPrismaService },
+      ],
+    }).compile();
+
+    service = module.get<ProjectsService>(ProjectsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a project and return it', async () => {
+      const dto = { name: 'My Project', description: 'A test project' };
+      const created = { id: 'proj-1', name: dto.name, description: dto.description, createdAt: new Date() };
+      mockPrismaProject.create.mockResolvedValue(created);
+
+      const result = await service.create(dto);
+
+      expect(mockPrismaProject.create).toHaveBeenCalledWith({ data: dto });
+      expect(result).toEqual(created);
+    });
+
+    it('should create a project without optional description', async () => {
+      const dto = { name: 'Minimal Project' };
+      const created = { id: 'proj-2', name: dto.name, description: null, createdAt: new Date() };
+      mockPrismaProject.create.mockResolvedValue(created);
+
+      const result = await service.create(dto);
+
+      expect(mockPrismaProject.create).toHaveBeenCalledWith({ data: dto });
+      expect(result).toEqual(created);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all projects', async () => {
+      const projects = [
+        { id: 'proj-1', name: 'Project A', description: null, createdAt: new Date() },
+        { id: 'proj-2', name: 'Project B', description: 'Desc', createdAt: new Date() },
+      ];
+      mockPrismaProject.findMany.mockResolvedValue(projects);
+
+      const result = await service.findAll();
+
+      expect(mockPrismaProject.findMany).toHaveBeenCalled();
+      expect(result).toEqual(projects);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a project when found', async () => {
+      const project = { id: 'proj-1', name: 'Project A', description: null, createdAt: new Date() };
+      mockPrismaProject.findUnique.mockResolvedValue(project);
+
+      const result = await service.findOne('proj-1');
+
+      expect(mockPrismaProject.findUnique).toHaveBeenCalledWith({ where: { id: 'proj-1' } });
+      expect(result).toEqual(project);
+    });
+
+    it('should return null when project is not found', async () => {
+      mockPrismaProject.findUnique.mockResolvedValue(null);
+
+      const result = await service.findOne('nonexistent-id');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('update', () => {
+    it('should update a project and return it', async () => {
+      const dto = { name: 'Updated Name' };
+      const updated = { id: 'proj-1', name: 'Updated Name', description: null, createdAt: new Date() };
+      mockPrismaProject.update.mockResolvedValue(updated);
+
+      const result = await service.update('proj-1', dto);
+
+      expect(mockPrismaProject.update).toHaveBeenCalledWith({
+        where: { id: 'proj-1' },
+        data: dto,
+      });
+      expect(result).toEqual(updated);
+    });
+
+    it('should throw NotFoundException on P2025 (project not found)', async () => {
+      const dto = { name: 'Ghost' };
+      const p2025Error = new Prisma.PrismaClientKnownRequestError(
+        'Record not found',
+        { code: 'P2025', clientVersion: '5.0.0' },
+      );
+      mockPrismaProject.update.mockRejectedValue(p2025Error);
+
+      await expect(service.update('nonexistent-id', dto)).rejects.toThrow(NotFoundException);
+      await expect(service.update('nonexistent-id', dto)).rejects.toThrow('Project not found');
+    });
+  });
+
+  describe('remove', () => {
+    it('should delete a project and return it', async () => {
+      const deleted = { id: 'proj-1', name: 'Project A', description: null, createdAt: new Date() };
+      mockPrismaProject.delete.mockResolvedValue(deleted);
+
+      const result = await service.remove('proj-1');
+
+      expect(mockPrismaProject.delete).toHaveBeenCalledWith({ where: { id: 'proj-1' } });
+      expect(result).toEqual(deleted);
+    });
+
+    it('should throw NotFoundException on P2025 (project not found)', async () => {
+      const p2025Error = new Prisma.PrismaClientKnownRequestError(
+        'Record not found',
+        { code: 'P2025', clientVersion: '5.0.0' },
+      );
+      mockPrismaProject.delete.mockRejectedValue(p2025Error);
+
+      await expect(service.remove('nonexistent-id')).rejects.toThrow(NotFoundException);
+      await expect(service.remove('nonexistent-id')).rejects.toThrow('Project not found');
+    });
+  });
+});

--- a/apps/api/src/projects/projects.service.ts
+++ b/apps/api/src/projects/projects.service.ts
@@ -1,0 +1,50 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateProjectDto } from '../dto/create-project.dto';
+import { UpdateProjectDto } from '../dto/update-project.dto';
+import { Prisma } from '@prisma/client';
+
+@Injectable()
+export class ProjectsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  create(dto: CreateProjectDto) {
+    return this.prisma.project.create({ data: dto });
+  }
+
+  findAll() {
+    return this.prisma.project.findMany();
+  }
+
+  findOne(id: string) {
+    return this.prisma.project.findUnique({ where: { id } });
+  }
+
+  async update(id: string, dto: UpdateProjectDto) {
+    try {
+      return await this.prisma.project.update({ where: { id }, data: dto });
+    } catch (e) {
+      if (
+        e instanceof Prisma.PrismaClientKnownRequestError &&
+        e.code === 'P2025'
+      ) {
+        throw new NotFoundException('Project not found');
+      }
+      throw e;
+    }
+  }
+
+  async remove(id: string) {
+    try {
+      return await this.prisma.project.delete({ where: { id } });
+    } catch (e) {
+      if (
+        e instanceof Prisma.PrismaClientKnownRequestError &&
+        e.code === 'P2025'
+      ) {
+        throw new NotFoundException('Project not found');
+      }
+      throw e;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

PR #28 was merged but the merge commit (`262f423`) landed on the tip of the slice-3 branch (`80c5bdd`) instead of main's HEAD (`ffa941b`), leaving the Projects module out of main.

This PR cherry-picks `8744f0a` (the Projects module commit) cleanly onto main.

## Changes

- `apps/api/src/projects/projects.service.ts` — ProjectsService CRUD backed by Prisma
- `apps/api/src/projects/projects.controller.ts` — REST endpoints (GET/POST/PUT/DELETE)
- `apps/api/src/projects/projects.module.ts` — NestJS module
- `apps/api/src/dto/create-project.dto.ts` / `update-project.dto.ts` — DTOs
- `apps/api/src/projects/projects.service.spec.ts` — Unit tests with Prisma mock
- `apps/api/src/app.module.ts` — ProjectsModule registered