### PR TITLE
test(issue-17): unit y e2e — auth, tasks, full flow

### DIFF
--- a/apps/api/.env.test.example
+++ b/apps/api/.env.test.example
@@ -1,0 +1,2 @@
+JWT_SECRET=replace-me
+DATABASE_URL=postgresql://USER:PASS@localhost:5432/mantys_kanban_test

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,0 +1,13 @@
+# API
+
+NestJS API for Mantys Kanban.
+
+## Local E2E Setup
+
+The e2e tests require a local PostgreSQL database. Before running `npm run test:e2e`:
+
+1. Create the test database and push the schema:
+   ```bash
+   DATABASE_URL=postgresql://postgres:postgres@localhost:5432/mantys_kanban_test npx prisma db push
+   ```
+2. Copy `.env.test.example` to `.env.test` and fill in your credentials.

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -70,6 +70,13 @@ describe('AuthService', () => {
       expect(result).toEqual(createdUser);
       expect((result as any).password).toBeUndefined();
     });
+
+    it('should propagate errors from usersService.create', async () => {
+      mockUsersService.create.mockRejectedValue(new Error('db error'));
+      await expect(
+        service.register({ email: 'x@x.com', password: 'p', name: 'X' }),
+      ).rejects.toThrow('db error');
+    });
   });
 
   describe('validateUser', () => {

--- a/apps/api/src/tasks/tasks.service.spec.ts
+++ b/apps/api/src/tasks/tasks.service.spec.ts
@@ -101,6 +101,12 @@ describe('TasksService', () => {
 
       expect(result).toBeNull();
     });
+
+    it('should rethrow non-P2025 errors from update', async () => {
+      const genericError = new Error('unexpected');
+      mockPrisma.task.update.mockRejectedValue(genericError);
+      await expect(service.update('id', { title: 'x' } as any)).rejects.toThrow('unexpected');
+    });
   });
 
   describe('remove', () => {
@@ -124,6 +130,12 @@ describe('TasksService', () => {
       const result = await service.remove('missing');
 
       expect(result).toBeNull();
+    });
+
+    it('should rethrow non-P2025 errors from remove', async () => {
+      const genericError = new Error('unexpected');
+      mockPrisma.task.delete.mockRejectedValue(genericError);
+      await expect(service.remove('id')).rejects.toThrow('unexpected');
     });
   });
 });

--- a/apps/api/test/tasks.e2e-spec.ts
+++ b/apps/api/test/tasks.e2e-spec.ts
@@ -104,4 +104,59 @@ describe('TasksController (e2e)', () => {
       expect(found).toBeNull();
     });
   });
+
+  describe('Full flow: login → create task → move status', () => {
+    const flowUser = {
+      email: 'flow-e2e@example.com',
+      password: 'test123',
+      name: 'Flow E2E',
+    };
+    let accessToken: string;
+
+    beforeEach(async () => {
+      await prisma.user.deleteMany({ where: { email: flowUser.email } });
+      await request(app.getHttpServer()).post('/auth/register').send(flowUser);
+      const loginRes = await request(app.getHttpServer())
+        .post('/auth/login')
+        .send({ email: flowUser.email, password: flowUser.password });
+      accessToken = loginRes.body.accessToken;
+    });
+
+    afterAll(async () => {
+      await prisma.user.deleteMany({ where: { email: flowUser.email } });
+    });
+
+    it('should create a task (BACKLOG), move to IN_PROGRESS, then to DONE', async () => {
+      // Create task — note: projectId is set by the outer beforeEach
+      const createRes = await request(app.getHttpServer())
+        .post('/tasks')
+        .send({ title: 'Flow Task', projectId })
+        .expect(HttpStatus.CREATED);
+
+      expect(createRes.body.status).toBe('BACKLOG');
+      const taskId = createRes.body.id;
+
+      // Move to IN_PROGRESS
+      const inProgressRes = await request(app.getHttpServer())
+        .put(`/tasks/${taskId}`)
+        .send({ status: 'IN_PROGRESS' })
+        .expect(HttpStatus.OK);
+
+      expect(inProgressRes.body.status).toBe('IN_PROGRESS');
+
+      // Move to DONE
+      const doneRes = await request(app.getHttpServer())
+        .put(`/tasks/${taskId}`)
+        .send({ status: 'DONE' })
+        .expect(HttpStatus.OK);
+
+      expect(doneRes.body.status).toBe('DONE');
+      expect(doneRes.body.title).toBe('Flow Task');
+    });
+
+    it('should have obtained a valid accessToken during login', () => {
+      expect(typeof accessToken).toBe('string');
+      expect(accessToken.length).toBeGreaterThan(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `DATABASE_URL` to `apps/api/.env.test` (gitignored locally; CI already injects it) and creates `.env.test.example` as reference
- Adds 3 unit test paths: `register()` rejection propagation (AuthService), non-P2025 rethrow on `update()` and `remove()` (TasksService) — 54 → 57 tests
- Adds a full-flow e2e describe block: register → login → create task (`BACKLOG`) → `IN_PROGRESS` → `DONE` — 16 → 18 e2e tests
- Creates `apps/api/README.md` with local e2e setup instructions

Closes #17

## Test plan

- [ ] `npm run test` in `apps/api/` — 57 tests, all green
- [ ] `npm run test:e2e` in `apps/api/` — 18 tests, all green (requires local `mantys_kanban_test` DB)
- [ ] "Full flow: login → create task → move status" describe block visible in e2e output