### PR TITLE
feat(web): auth flow — login page, httpOnly cookie, route middleware

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+const COOKIE_NAME = 'auth-token'
+const PUBLIC_PATHS = ['/login']
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+  const token = request.cookies.get(COOKIE_NAME)?.value
+  const isPublicPath = PUBLIC_PATHS.some((p) => pathname === p)
+
+  if (!token && !isPublicPath) {
+    return NextResponse.redirect(new URL('/login', request.url))
+  }
+  if (token && isPublicPath) {
+    return NextResponse.redirect(new URL('/board', request.url))
+  }
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico|public/).*)'],
+}

--- a/apps/web/src/app/actions/auth.ts
+++ b/apps/web/src/app/actions/auth.ts
@@ -1,0 +1,58 @@
+'use server'
+
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+import type { LoginResponse } from '@mantys/types'
+
+const COOKIE_NAME = 'auth-token'
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 7 // 7 days
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3000'
+
+export type LoginState = { error: string } | undefined
+
+export async function loginAction(
+  _prevState: LoginState,
+  formData: FormData,
+): Promise<LoginState> {
+  const email = formData.get('email') as string
+  const password = formData.get('password') as string
+
+  let success = false
+
+  try {
+    const res = await fetch(`${API_URL}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+      cache: 'no-store',
+    })
+
+    if (!res.ok) {
+      return { error: 'Invalid email or password' }
+    }
+
+    const data: LoginResponse = await res.json()
+
+    cookies().set(COOKIE_NAME, data.accessToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: COOKIE_MAX_AGE,
+      path: '/',
+    })
+
+    success = true
+  } catch {
+    return { error: 'Something went wrong. Please try again.' }
+  }
+
+  // redirect() throws a Next.js control-flow signal — it MUST run outside
+  // try/catch or the catch would swallow it and break navigation.
+  if (success) redirect('/board')
+  return undefined
+}
+
+export async function logoutAction() {
+  cookies().delete(COOKIE_NAME)
+  redirect('/login')
+}

--- a/apps/web/src/app/board/page.tsx
+++ b/apps/web/src/app/board/page.tsx
@@ -1,0 +1,16 @@
+import { logoutAction } from '../actions/auth'
+import { Button } from '@/components/ui/button'
+
+export default function BoardPage() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center gap-4">
+      <h1 className="text-2xl font-bold">MANTYS Kanban</h1>
+      <p className="text-muted-foreground">Board coming in issue #22</p>
+      <form action={logoutAction}>
+        <Button variant="outline" type="submit">
+          Log out
+        </Button>
+      </form>
+    </div>
+  )
+}

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { useFormState, useFormStatus } from 'react-dom'
+import { loginAction, type LoginState } from '../actions/auth'
+import { Button } from '@/components/ui/button'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+
+const initialState: LoginState = undefined
+
+function SubmitButton() {
+  const { pending } = useFormStatus()
+  return (
+    <Button type="submit" disabled={pending} className="w-full">
+      {pending ? 'Signing in…' : 'Sign in'}
+    </Button>
+  )
+}
+
+export default function LoginPage() {
+  const [state, action] = useFormState(loginAction, initialState)
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle className="text-center">MANTYS Kanban</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form action={action} className="space-y-4">
+            <div className="space-y-2">
+              <label htmlFor="email" className="text-sm font-medium">
+                Email
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                required
+                autoComplete="email"
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                placeholder="you@example.com"
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="password" className="text-sm font-medium">
+                Password
+              </label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                required
+                autoComplete="current-password"
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              />
+            </div>
+            {state?.error && (
+              <p className="text-sm text-destructive">{state.error}</p>
+            )}
+            <SubmitButton />
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation'
 
 export default function Home() {
-  redirect('/login')
+  redirect('/board')
 }


### PR DESCRIPTION
## Summary

- Adds `/login` page with email/password form using React 18 `useFormState` + `useFormStatus`
- `loginAction` Server Action calls `POST /auth/login`, stores JWT in `auth-token` httpOnly cookie (7d, secure in prod only)
- Edge `middleware.ts` gates all routes: no cookie → redirect `/login`; cookie on `/login` → redirect `/board`
- `logoutAction` clears cookie and redirects to `/login`
- Adds `/board` placeholder page with logout button (full Kanban UI in #22)
- Updates root `/` to redirect to `/board` (middleware handles the unauthenticated case before the page renders)

## Implementation notes

- Server Action pattern (not Route Handler) — idiomatic Next.js 14 App Router
- Trust-on-existence middleware (no JWT signature verification) — API is the real firewall
- `redirect()` called after try/catch, never inside — avoids swallowing Next.js's internal throw
- `useFormStatus` placed in a child `SubmitButton` component inside the form (React 18 constraint)

## Test plan

- [x] `npx tsc --noEmit` in `apps/web/` — 0 errors
- [x] `npm run test` in `apps/api/` — 57/57 pass
- [ ] Manual: start API (`npm run dev:api`) + web (`npm run dev:web`), visit http://localhost:3001 → redirects to /login → login with valid credentials → redirects to /board → logout → back to /login

Closes #21