### PR TITLE
feat(projects): create, edit, delete projects from sidebar (#40)

### DIFF
--- a/apps/api/src/tasks/tasks.service.spec.ts
+++ b/apps/api/src/tasks/tasks.service.spec.ts
@@ -43,7 +43,10 @@ describe('TasksService', () => {
 
       const result = await service.create(dto as any);
 
-      expect(mockPrisma.task.create).toHaveBeenCalledWith({ data: dto });
+      expect(mockPrisma.task.create).toHaveBeenCalledWith({
+        data: dto,
+        include: { assignee: { select: { id: true, name: true, email: true } } },
+      });
       expect(result).toEqual(created);
     });
   });

--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -9,7 +9,10 @@ export class TasksService {
   constructor(private readonly prisma: PrismaService) {}
 
   create(dto: CreateTaskDto) {
-    return this.prisma.task.create({ data: dto });
+    return this.prisma.task.create({
+      data: dto,
+      include: { assignee: { select: { id: true, name: true, email: true } } },
+    });
   }
 
   findAll(projectId?: string) {

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,6 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   transpilePackages: ['@mantys/types'],
+  experimental: {
+    staleTimes: {
+      dynamic: 0,
+    },
+  },
 }
 
 export default nextConfig

--- a/apps/web/src/app/board/page.tsx
+++ b/apps/web/src/app/board/page.tsx
@@ -45,6 +45,7 @@ export default async function BoardPage({
     <div className="flex h-screen bg-[#0d0d0f]">
       <Sidebar projects={projects} activeProjectId={projectId} />
       <KanbanBoard
+        key={projectId ?? 'all'}
         initialTasks={tasks}
         projects={projects}
         users={users}

--- a/apps/web/src/app/board/page.tsx
+++ b/apps/web/src/app/board/page.tsx
@@ -50,6 +50,7 @@ export default async function BoardPage({
         projects={projects}
         users={users}
         currentUser={currentUser}
+        activeProjectId={projectId}
       />
     </div>
   )

--- a/apps/web/src/components/board/KanbanBoard.tsx
+++ b/apps/web/src/components/board/KanbanBoard.tsx
@@ -60,9 +60,10 @@ interface Props {
   projects: Project[]
   users: User[]
   currentUser: { name?: string; email?: string } | null
+  activeProjectId?: string
 }
 
-export default function KanbanBoard({ initialTasks, projects, users, currentUser }: Props) {
+export default function KanbanBoard({ initialTasks, projects, users, currentUser, activeProjectId }: Props) {
   const [tasks, setTasks] = useState<Task[]>(initialTasks)
   const [activeTask, setActiveTask] = useState<Task | null>(null)
   const [dragError, setDragError] = useState(false)
@@ -291,6 +292,7 @@ export default function KanbanBoard({ initialTasks, projects, users, currentUser
           mode={modalState.mode}
           task={modalState.task}
           columnStatus={modalState.columnStatus}
+          activeProjectId={activeProjectId}
           projects={projects}
           users={users}
           onClose={closeModal}

--- a/apps/web/src/components/board/KanbanBoard.tsx
+++ b/apps/web/src/components/board/KanbanBoard.tsx
@@ -193,14 +193,14 @@ export default function KanbanBoard({ initialTasks, projects, users, currentUser
       <div className="flex items-center gap-4 px-5 py-2.5 border-b border-[#1d1d21] bg-[#0d0d0f] flex-shrink-0 overflow-x-auto">
         {/* Assignee filter */}
         <div className="flex items-center gap-1.5 flex-shrink-0">
-          <span className="text-xs text-[#52525b] font-medium">Assignee:</span>
+          <span className="text-xs text-[#71717a] font-medium">Assignee:</span>
           <button
             onClick={() => setActiveAssignee(null)}
             className={cn(
               'text-xs px-2.5 py-1 rounded-full transition-colors',
               activeAssignee === null
                 ? 'bg-indigo-600 text-white'
-                : 'bg-[#1d1d21] text-[#71717a] hover:text-[#a1a1aa]',
+                : 'bg-[#27272b] text-[#a1a1aa] hover:text-[#e4e4e7] hover:bg-[#3f3f46]',
             )}
           >
             All
@@ -213,7 +213,7 @@ export default function KanbanBoard({ initialTasks, projects, users, currentUser
                 'text-xs px-2.5 py-1 rounded-full transition-colors',
                 activeAssignee === u.id
                   ? 'bg-indigo-600 text-white'
-                  : 'bg-[#1d1d21] text-[#71717a] hover:text-[#a1a1aa]',
+                  : 'bg-[#27272b] text-[#a1a1aa] hover:text-[#e4e4e7] hover:bg-[#3f3f46]',
               )}
             >
               {getInitials(u.name, u.email)}
@@ -225,14 +225,14 @@ export default function KanbanBoard({ initialTasks, projects, users, currentUser
 
         {/* Priority filter */}
         <div className="flex items-center gap-1.5 flex-shrink-0">
-          <span className="text-xs text-[#52525b] font-medium">Priority:</span>
+          <span className="text-xs text-[#71717a] font-medium">Priority:</span>
           <button
             onClick={() => setActivePriority(null)}
             className={cn(
               'text-xs px-2.5 py-1 rounded-full transition-colors',
               activePriority === null
                 ? 'bg-indigo-600 text-white'
-                : 'bg-[#1d1d21] text-[#71717a] hover:text-[#a1a1aa]',
+                : 'bg-[#27272b] text-[#a1a1aa] hover:text-[#e4e4e7] hover:bg-[#3f3f46]',
             )}
           >
             All
@@ -245,7 +245,7 @@ export default function KanbanBoard({ initialTasks, projects, users, currentUser
                 'text-xs px-2.5 py-1 rounded-full transition-colors',
                 activePriority === p
                   ? PRIORITY_PILL[p]
-                  : 'bg-[#1d1d21] text-[#71717a] hover:text-[#a1a1aa]',
+                  : 'bg-[#27272b] text-[#a1a1aa] hover:text-[#e4e4e7] hover:bg-[#3f3f46]',
               )}
             >
               {p}

--- a/apps/web/src/components/board/ProjectModal.tsx
+++ b/apps/web/src/components/board/ProjectModal.tsx
@@ -1,0 +1,170 @@
+'use client'
+
+import { useState } from 'react'
+import type { Project } from '@mantys/types'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+
+interface Props {
+  mode: 'create' | 'edit'
+  project?: Project
+  onClose: () => void
+  onSave: (project: Project) => void
+  onDelete?: (projectId: string) => void
+}
+
+const BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3002'
+
+export default function ProjectModal({ mode, project, onClose, onSave, onDelete }: Props) {
+  const [name, setName] = useState(project?.name ?? '')
+  const [description, setDescription] = useState(project?.description ?? '')
+  const [loading, setLoading] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!name.trim()) return
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch(
+        mode === 'create' ? `${BASE}/projects` : `${BASE}/projects/${project!.id}`,
+        {
+          method: mode === 'create' ? 'POST' : 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: name.trim(), description: description.trim() || undefined }),
+        },
+      )
+      if (!res.ok) throw new Error('Failed to save project')
+      const saved: Project = await res.json()
+      onSave(saved)
+    } catch {
+      setError('Could not save project. Try again.')
+      setLoading(false)
+    }
+  }
+
+  async function handleDelete() {
+    if (!project) return
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch(`${BASE}/projects/${project.id}`, { method: 'DELETE' })
+      if (!res.ok) throw new Error('Failed to delete project')
+      onDelete?.(project.id)
+    } catch {
+      setError('Could not delete project. Try again.')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="bg-[#18181c] border-[#27272b] text-[#d4d4d8] max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="text-[#e4e4e7] text-base">
+            {mode === 'create' ? 'New Project' : 'Edit Project'}
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            {mode === 'create' ? 'Fill in the fields to create a new project.' : 'Edit the project fields and save.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        {confirmDelete ? (
+          <div className="space-y-4">
+            <p className="text-sm text-[#a1a1aa]">
+              Delete <span className="text-[#e4e4e7] font-medium">{project?.name}</span>? This cannot be undone.
+            </p>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setConfirmDelete(false)}
+                className="flex-1 border-[#27272b] text-[#a1a1aa] bg-transparent hover:bg-[#27272b]"
+              >
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                onClick={handleDelete}
+                disabled={loading}
+                className="flex-1 bg-[#450a0a] hover:bg-[#7f1d1d] text-[#f87171] border-0"
+              >
+                {loading ? 'Deleting…' : 'Delete'}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <div>
+              <label className="block text-xs font-medium text-[#a1a1aa] mb-1.5" htmlFor="proj-name">
+                Name <span className="text-[#ef4444]">*</span>
+              </label>
+              <input
+                id="proj-name"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Impresiones 3D"
+                required
+                className="w-full px-3 py-2 rounded-lg bg-[#111115] border border-[#27272b] text-sm text-white placeholder-[#52525b] focus:outline-none focus:border-indigo-500 transition-colors"
+              />
+            </div>
+
+            <div>
+              <label className="block text-xs font-medium text-[#a1a1aa] mb-1.5" htmlFor="proj-desc">
+                Description <span className="text-[#52525b]">(optional)</span>
+              </label>
+              <textarea
+                id="proj-desc"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="What is this project about?"
+                rows={2}
+                className="w-full px-3 py-2 rounded-lg bg-[#111115] border border-[#27272b] text-sm text-white placeholder-[#52525b] focus:outline-none focus:border-indigo-500 transition-colors resize-none"
+              />
+            </div>
+
+            {error && (
+              <p className="text-xs text-[#f87171] bg-[#1f0606] border border-[#450a0a] rounded-lg px-3 py-2">
+                {error}
+              </p>
+            )}
+
+            <div className="flex items-center gap-2 pt-1">
+              {mode === 'edit' && (
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={() => setConfirmDelete(true)}
+                  className="bg-transparent hover:bg-[#1f0606] text-[#f87171] border border-[#450a0a] text-xs"
+                >
+                  Delete
+                </Button>
+              )}
+              <div className="flex-1" />
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={onClose}
+                className="border-[#27272b] text-[#a1a1aa] bg-transparent hover:bg-[#27272b] text-xs"
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                size="sm"
+                disabled={loading || !name.trim()}
+                className="bg-indigo-600 hover:bg-indigo-500 text-white text-xs disabled:opacity-50"
+              >
+                {loading ? 'Saving…' : mode === 'create' ? 'Create' : 'Save'}
+              </Button>
+            </div>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/board/Sidebar.tsx
+++ b/apps/web/src/components/board/Sidebar.tsx
@@ -1,45 +1,109 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import type { Project } from '@mantys/types'
 import { cn } from '@/lib/utils'
+import ProjectModal from './ProjectModal'
 
 interface Props {
   projects: Project[]
   activeProjectId?: string
 }
 
-export default function Sidebar({ projects, activeProjectId }: Props) {
+export default function Sidebar({ projects: initialProjects, activeProjectId }: Props) {
+  const router = useRouter()
+  const [projects, setProjects] = useState<Project[]>(initialProjects)
+  const [modal, setModal] = useState<{ open: boolean; mode: 'create' | 'edit'; project?: Project }>({
+    open: false,
+    mode: 'create',
+  })
+
+  function openCreate() {
+    setModal({ open: true, mode: 'create' })
+  }
+
+  function openEdit(project: Project) {
+    setModal({ open: true, mode: 'edit', project })
+  }
+
+  function handleSave(saved: Project) {
+    setProjects((prev) => {
+      const exists = prev.find((p) => p.id === saved.id)
+      return exists ? prev.map((p) => (p.id === saved.id ? saved : p)) : [...prev, saved]
+    })
+    setModal({ open: false, mode: 'create' })
+    if (modal.mode === 'create') {
+      router.push(`/board?projectId=${saved.id}`)
+    }
+  }
+
+  function handleDelete(projectId: string) {
+    setProjects((prev) => prev.filter((p) => p.id !== projectId))
+    setModal({ open: false, mode: 'create' })
+    if (activeProjectId === projectId) router.push('/board')
+  }
+
   return (
-    <aside className="w-56 flex-shrink-0 bg-[#101013] border-r border-[#1d1d21] flex flex-col">
-      <div className="px-4 py-4 border-b border-[#1d1d21]">
-        <span className="text-xs font-semibold uppercase tracking-widest text-[#52525b]">Projects</span>
-      </div>
-      <nav className="flex-1 overflow-y-auto p-2">
-        <Link
-          href="/board"
-          className={cn(
-            'flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors',
-            !activeProjectId
-              ? 'bg-[#18181c] text-[#e4e4e7]'
-              : 'text-[#71717a] hover:bg-[#18181c] hover:text-[#a1a1aa]',
-          )}
-        >
-          All projects
-        </Link>
-        {projects.map((p) => (
+    <>
+      <aside className="w-56 flex-shrink-0 bg-[#101013] border-r border-[#1d1d21] flex flex-col">
+        <div className="px-4 py-4 border-b border-[#1d1d21] flex items-center justify-between">
+          <span className="text-xs font-semibold uppercase tracking-widest text-[#52525b]">Projects</span>
+          <button
+            onClick={openCreate}
+            title="New project"
+            className="w-5 h-5 flex items-center justify-center text-[#52525b] hover:text-[#a1a1aa] transition-colors text-base leading-none"
+          >
+            +
+          </button>
+        </div>
+        <nav className="flex-1 overflow-y-auto p-2">
           <Link
-            key={p.id}
-            href={`/board?projectId=${p.id}`}
+            href="/board"
             className={cn(
-              'flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors mt-0.5',
-              activeProjectId === p.id
+              'flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors',
+              !activeProjectId
                 ? 'bg-[#18181c] text-[#e4e4e7]'
                 : 'text-[#71717a] hover:bg-[#18181c] hover:text-[#a1a1aa]',
             )}
           >
-            {p.name}
+            All projects
           </Link>
-        ))}
-      </nav>
-    </aside>
+          {projects.map((p) => (
+            <div key={p.id} className="group relative mt-0.5">
+              <Link
+                href={`/board?projectId=${p.id}`}
+                className={cn(
+                  'flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors pr-8',
+                  activeProjectId === p.id
+                    ? 'bg-[#18181c] text-[#e4e4e7]'
+                    : 'text-[#71717a] hover:bg-[#18181c] hover:text-[#a1a1aa]',
+                )}
+              >
+                {p.name}
+              </Link>
+              <button
+                onClick={() => openEdit(p)}
+                title="Edit project"
+                className="absolute right-2 top-1/2 -translate-y-1/2 w-5 h-5 flex items-center justify-center text-[#52525b] hover:text-[#a1a1aa] opacity-0 group-hover:opacity-100 transition-opacity text-xs"
+              >
+                ✎
+              </button>
+            </div>
+          ))}
+        </nav>
+      </aside>
+
+      {modal.open && (
+        <ProjectModal
+          mode={modal.mode}
+          project={modal.project}
+          onClose={() => setModal({ open: false, mode: 'create' })}
+          onSave={handleSave}
+          onDelete={handleDelete}
+        />
+      )}
+    </>
   )
 }

--- a/apps/web/src/components/board/Sidebar.tsx
+++ b/apps/web/src/components/board/Sidebar.tsx
@@ -40,9 +40,14 @@ export default function Sidebar({ projects: initialProjects, activeProjectId }: 
   }
 
   function handleDelete(projectId: string) {
-    setProjects((prev) => prev.filter((p) => p.id !== projectId))
+    const remaining = projects.filter((p) => p.id !== projectId)
+    setProjects(remaining)
     setModal({ open: false, mode: 'create' })
-    if (activeProjectId === projectId) router.push('/board')
+    if (remaining.length === 0) {
+      router.push('/projects/new')
+    } else if (activeProjectId === projectId) {
+      router.push('/board')
+    }
   }
 
   return (

--- a/apps/web/src/components/board/Sidebar.tsx
+++ b/apps/web/src/components/board/Sidebar.tsx
@@ -49,7 +49,7 @@ export default function Sidebar({ projects: initialProjects, activeProjectId }: 
     <>
       <aside className="w-56 flex-shrink-0 bg-[#101013] border-r border-[#1d1d21] flex flex-col">
         <div className="px-4 py-4 border-b border-[#1d1d21] flex items-center justify-between">
-          <span className="text-xs font-semibold uppercase tracking-widest text-[#52525b]">Projects</span>
+          <span className="text-xs font-semibold uppercase tracking-widest text-[#71717a]">Projects</span>
           <button
             onClick={openCreate}
             title="New project"
@@ -65,7 +65,7 @@ export default function Sidebar({ projects: initialProjects, activeProjectId }: 
               'flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors',
               !activeProjectId
                 ? 'bg-[#18181c] text-[#e4e4e7]'
-                : 'text-[#71717a] hover:bg-[#18181c] hover:text-[#a1a1aa]',
+                : 'text-[#a1a1aa] hover:bg-[#18181c] hover:text-[#e4e4e7]',
             )}
           >
             All projects
@@ -78,7 +78,7 @@ export default function Sidebar({ projects: initialProjects, activeProjectId }: 
                   'flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors pr-8',
                   activeProjectId === p.id
                     ? 'bg-[#18181c] text-[#e4e4e7]'
-                    : 'text-[#71717a] hover:bg-[#18181c] hover:text-[#a1a1aa]',
+                    : 'text-[#a1a1aa] hover:bg-[#18181c] hover:text-[#e4e4e7]',
                 )}
               >
                 {p.name}

--- a/apps/web/src/components/board/Sidebar.tsx
+++ b/apps/web/src/components/board/Sidebar.tsx
@@ -53,7 +53,7 @@ export default function Sidebar({ projects: initialProjects, activeProjectId }: 
           <button
             onClick={openCreate}
             title="New project"
-            className="w-5 h-5 flex items-center justify-center text-[#52525b] hover:text-[#a1a1aa] transition-colors text-base leading-none"
+            className="w-5 h-5 flex items-center justify-center text-[#71717a] hover:text-[#e4e4e7] transition-colors text-base leading-none"
           >
             +
           </button>
@@ -86,7 +86,7 @@ export default function Sidebar({ projects: initialProjects, activeProjectId }: 
               <button
                 onClick={() => openEdit(p)}
                 title="Edit project"
-                className="absolute right-2 top-1/2 -translate-y-1/2 w-5 h-5 flex items-center justify-center text-[#52525b] hover:text-[#a1a1aa] opacity-0 group-hover:opacity-100 transition-opacity text-xs"
+                className="absolute right-2 top-1/2 -translate-y-1/2 w-5 h-5 flex items-center justify-center text-[#71717a] hover:text-[#e4e4e7] opacity-0 group-hover:opacity-100 transition-opacity text-xs"
               >
                 ✎
               </button>

--- a/apps/web/src/components/board/TaskModal.tsx
+++ b/apps/web/src/components/board/TaskModal.tsx
@@ -34,6 +34,7 @@ interface Props {
   mode: 'create' | 'edit'
   task?: Task
   columnStatus?: TaskStatus
+  activeProjectId?: string
   projects: Project[]
   users: User[]
   onClose: () => void
@@ -50,6 +51,7 @@ export default function TaskModal({
   mode,
   task,
   columnStatus,
+  activeProjectId,
   projects,
   users,
   onClose,
@@ -57,7 +59,7 @@ export default function TaskModal({
   onDelete,
 }: Props) {
   const defaultStatus = task?.status ?? columnStatus ?? TaskStatus.BACKLOG
-  const defaultProjectId = task?.projectId ?? projects[0]?.id ?? ''
+  const defaultProjectId = task?.projectId ?? activeProjectId ?? projects[0]?.id ?? ''
 
   const [title, setTitle] = useState(task?.title ?? '')
   const [description, setDescription] = useState(task?.description ?? '')
@@ -233,22 +235,24 @@ export default function TaskModal({
             </div>
           </div>
 
-          {/* Project */}
-          <div>
-            <label className={labelClass}>Project *</label>
-            <select
-              className={inputClass}
-              value={projectId}
-              onChange={(e) => setProjectId(e.target.value)}
-            >
-              <option value="">Select project</option>
-              {projects.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.name}
-                </option>
-              ))}
-            </select>
-          </div>
+          {/* Project — only shown when viewing all projects */}
+          {!activeProjectId && (
+            <div>
+              <label className={labelClass}>Project *</label>
+              <select
+                className={inputClass}
+                value={projectId}
+                onChange={(e) => setProjectId(e.target.value)}
+              >
+                <option value="">Select project</option>
+                {projects.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
 
           {error && (
             <p className="text-xs text-[#f87171] bg-[#1f0606] border border-[#450a0a] rounded-md px-3 py-2">


### PR DESCRIPTION
## Summary

- Adds **+** button in sidebar header to create a new project
- Hover on any project shows an edit (✎) button
- Create/edit modal: name (required) + description (optional)
- Edit modal includes delete with inline confirmation
- After creating a project, auto-navigates to `/board?projectId=<id>`
- After deleting active project, redirects to `/board`
- Optimistic sidebar update — no full page reload needed

## Files changed

- `apps/web/src/components/board/Sidebar.tsx` — converted to client component with modal state
- `apps/web/src/components/board/ProjectModal.tsx` — new create/edit/delete modal

## Test plan

- [x] TypeScript: `npx tsc --noEmit` — 0 errors
- [ ] Manual: + button → fill name → project appears in sidebar and board filters to it
- [ ] Manual: hover project → ✎ → edit name → updates in sidebar
- [ ] Manual: delete project → confirmation → removed from sidebar, redirects to /board

Closes #40