### PR TITLE
feat(auth): add POST /auth/register endpoint (#45)

### DIFF
--- a/apps/api/src/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/auth.controller.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * Test suite: AuthController
+ *
+ * Unit tests using a mocked AuthService.
+ * POST /auth/register is a public (unguarded) route — no overrideGuard needed.
+ * No database connection required.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException } from '@nestjs/common';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { CreateUserDto } from '../dto/create-user.dto';
+
+const mockAuthService = {
+  register: jest.fn(),
+  login: jest.fn(),
+};
+
+describe('AuthController', () => {
+  let controller: AuthController;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [{ provide: AuthService, useValue: mockAuthService }],
+    }).compile();
+
+    controller = module.get<AuthController>(AuthController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('register', () => {
+    const dto: CreateUserDto = {
+      email: 'alice@example.com',
+      password: 'secret123',
+      name: 'Alice',
+    };
+
+    it('should return the result from authService.register (no password in response)', async () => {
+      const serviceResult = { id: 'user-1', email: dto.email, name: dto.name, role: 'MEMBER', createdAt: new Date() };
+      mockAuthService.register.mockResolvedValue(serviceResult);
+
+      const result = await controller.register(dto);
+
+      expect(result).toEqual(serviceResult);
+      expect((result as any).password).toBeUndefined();
+    });
+
+    it('should propagate ConflictException when authService.register throws', async () => {
+      mockAuthService.register.mockRejectedValue(new ConflictException('Email already exists'));
+
+      await expect(controller.register(dto)).rejects.toThrow(ConflictException);
+    });
+
+    it('should forward the dto as-is to authService.register', async () => {
+      mockAuthService.register.mockResolvedValue({});
+
+      await controller.register(dto);
+
+      expect(mockAuthService.register).toHaveBeenCalledWith(dto);
+    });
+  });
+});

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -10,6 +10,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
+import { Role } from '@prisma/client';
 import { AuthService } from './auth.service';
 import { UsersService } from '../users/users.service';
 import { CreateUserDto } from '../dto/create-user.dto';
@@ -66,9 +67,30 @@ describe('AuthService', () => {
 
       const result = await service.register(dto);
 
-      expect(mockUsersService.create).toHaveBeenCalledWith(dto);
+      expect(mockUsersService.create).toHaveBeenCalledWith({ ...dto, role: Role.MEMBER });
       expect(result).toEqual(createdUser);
       expect((result as any).password).toBeUndefined();
+    });
+
+    it('should override role to MEMBER even when caller supplies role OWNER', async () => {
+      const dtoWithOwner: CreateUserDto = {
+        email: 'bob@example.com',
+        password: 'secret123',
+        name: 'Bob',
+        role: Role.OWNER,
+      };
+      const createdUser = {
+        id: 'user-2',
+        email: dtoWithOwner.email,
+        name: dtoWithOwner.name,
+        role: 'MEMBER',
+        createdAt: new Date(),
+      };
+      mockUsersService.create.mockResolvedValue(createdUser);
+
+      await service.register(dtoWithOwner);
+
+      expect(mockUsersService.create).toHaveBeenCalledWith({ ...dtoWithOwner, role: Role.MEMBER });
     });
 
     it('should propagate errors from usersService.create', async () => {

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
+import { Role } from '@prisma/client';
 import { UsersService } from '../users/users.service';
 import { CreateUserDto } from '../dto/create-user.dto';
 import { LoginDto } from '../dto/login.dto';
@@ -17,7 +18,7 @@ export class AuthService {
    * Returns the created user without the password field.
    */
   async register(dto: CreateUserDto) {
-    return this.usersService.create(dto);
+    return this.usersService.create({ ...dto, role: Role.MEMBER });
   }
 
   /**


### PR DESCRIPTION
Closes #45

## Type of change

- [x] New feature

## Summary

- Adds `POST /auth/register` public endpoint (controller + service were already implemented; this PR completes the contract)
- Fixes privilege escalation: `AuthService.register()` now forces `role: Role.MEMBER` regardless of what the caller passes in the DTO
- Adds `auth.controller.spec.ts` with 3 test cases (success, conflict propagation, dto forwarding)

## Changes

| File | Change |
|------|--------|
| `apps/api/src/auth/auth.service.ts` | Force `role: Role.MEMBER` via spread-override in `register()` |
| `apps/api/src/auth/auth.service.spec.ts` | Update assertion to match new role-stripping behavior; add role-override test |
| `apps/api/src/auth/auth.controller.spec.ts` | New file — controller unit tests (no guard override; register is public) |

## Test Plan

- [x] `cd apps/api && pnpm test` — 66/66 passing, 8 suites, 0 regressions
- [x] Role enforcement verified: POSTing `{ role: "OWNER" }` results in `MEMBER` stored
- [x] No changes to `UsersService`, DTO, or Prisma schema