### PR TITLE
feat(web): use project slug in board URL instead of raw CUID

### DIFF
--- a/apps/api/prisma/migrations/20260614120000_add_project_slug/migration.sql
+++ b/apps/api/prisma/migrations/20260614120000_add_project_slug/migration.sql
@@ -1,0 +1,55 @@
+-- Step 1: Add slug column as nullable (no constraint yet)
+ALTER TABLE "Project" ADD COLUMN "slug" TEXT;
+
+-- Step 2: Backfill slug for existing rows
+-- Slugify: lowercase, replace non-alnum runs with hyphen, strip leading/trailing hyphens.
+-- ROW_NUMBER() window partitioned by slugified name ensures unique slugs when two projects
+-- share the same name (first gets base slug, subsequent get base-2, base-3, etc.).
+-- NOTE: unaccent extension is NOT used (not guaranteed on all hosts).
+-- Accented characters become hyphens in SQL; JS slugify handles accents for new rows.
+UPDATE "Project" p
+SET "slug" = s.final_slug
+FROM (
+  SELECT
+    id,
+    CASE
+      WHEN rn = 1 THEN base_slug
+      ELSE base_slug || '-' || rn
+    END AS final_slug
+  FROM (
+    SELECT
+      id,
+      COALESCE(
+        NULLIF(
+          regexp_replace(
+            regexp_replace(lower("name"), '[^a-z0-9]+', '-', 'g'),
+            '^-+|-+$', '', 'g'
+          ),
+          ''
+        ),
+        'project'
+      ) AS base_slug,
+      ROW_NUMBER() OVER (
+        PARTITION BY
+          COALESCE(
+            NULLIF(
+              regexp_replace(
+                regexp_replace(lower("name"), '[^a-z0-9]+', '-', 'g'),
+                '^-+|-+$', '', 'g'
+              ),
+              ''
+            ),
+            'project'
+          )
+        ORDER BY "createdAt"
+      ) AS rn
+    FROM "Project"
+  ) sub
+) s
+WHERE p.id = s.id;
+
+-- Step 3: Set NOT NULL constraint now that all rows have a slug
+ALTER TABLE "Project" ALTER COLUMN "slug" SET NOT NULL;
+
+-- Step 4: Create unique index
+CREATE UNIQUE INDEX "Project_slug_key" ON "Project"("slug");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -40,6 +40,7 @@ model User {
 model Project {
   id          String   @id @default(cuid())
   name        String
+  slug        String   @unique
   description String?
   createdAt   DateTime @default(now())
   tasks       Task[]

--- a/apps/api/src/projects/projects.controller.spec.ts
+++ b/apps/api/src/projects/projects.controller.spec.ts
@@ -1,5 +1,6 @@
 /**
  * Test suite: ProjectsController — DELETE /projects/:id authorization
+ * and GET /projects/by-slug/:slug route delegation.
  *
  * Tests the role-based access control on the remove() handler.
  * JwtAuthGuard is overridden with a custom guard that injects a mock user
@@ -14,6 +15,7 @@ import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 const mockProjectsService = {
   remove: jest.fn(),
+  findBySlug: jest.fn(),
 };
 
 describe('ProjectsController', () => {
@@ -52,6 +54,18 @@ describe('ProjectsController', () => {
 
       expect(mockProjectsService.remove).toHaveBeenCalledTimes(1);
       expect(mockProjectsService.remove).toHaveBeenCalledWith('project-1');
+    });
+  });
+
+  describe('findBySlug (GET by-slug/:slug)', () => {
+    it('calls service.findBySlug with the slug and returns the result', async () => {
+      const project = { id: 'proj-1', name: 'My Project', slug: 'my-project', description: null, createdAt: new Date() };
+      mockProjectsService.findBySlug.mockResolvedValue(project);
+
+      const result = await controller.findBySlug('my-project');
+
+      expect(mockProjectsService.findBySlug).toHaveBeenCalledWith('my-project');
+      expect(result).toEqual(project);
     });
   });
 });

--- a/apps/api/src/projects/projects.controller.ts
+++ b/apps/api/src/projects/projects.controller.ts
@@ -33,6 +33,19 @@ export class ProjectsController {
   }
 
   /**
+   * Retrieve a single project by slug.
+   * IMPORTANT: This route MUST be declared BEFORE @Get(':id') so NestJS
+   * does not capture the literal string 'by-slug' as an :id parameter.
+   */
+  @ApiOperation({ summary: 'Get a project by slug' })
+  @ApiResponse({ status: 200, description: 'Returns the project' })
+  @ApiResponse({ status: 404, description: 'Project not found' })
+  @Get('by-slug/:slug')
+  findBySlug(@Param('slug') slug: string) {
+    return this.projectsService.findBySlug(slug);
+  }
+
+  /**
    * Retrieve a single project by ID
    */
   @ApiOperation({ summary: 'Get a project by ID' })

--- a/apps/api/src/projects/projects.service.spec.ts
+++ b/apps/api/src/projects/projects.service.spec.ts
@@ -46,23 +46,29 @@ describe('ProjectsService', () => {
   describe('create', () => {
     it('should create a project and return it', async () => {
       const dto = { name: 'My Project', description: 'A test project' };
-      const created = { id: 'proj-1', name: dto.name, description: dto.description, createdAt: new Date() };
+      const created = { id: 'proj-1', name: dto.name, slug: 'my-project', description: dto.description, createdAt: new Date() };
+      mockPrismaProject.findMany.mockResolvedValue([]);
       mockPrismaProject.create.mockResolvedValue(created);
 
       const result = await service.create(dto);
 
-      expect(mockPrismaProject.create).toHaveBeenCalledWith({ data: dto });
+      expect(mockPrismaProject.create).toHaveBeenCalledWith({
+        data: { ...dto, slug: 'my-project' },
+      });
       expect(result).toEqual(created);
     });
 
     it('should create a project without optional description', async () => {
       const dto = { name: 'Minimal Project' };
-      const created = { id: 'proj-2', name: dto.name, description: null, createdAt: new Date() };
+      const created = { id: 'proj-2', name: dto.name, slug: 'minimal-project', description: null, createdAt: new Date() };
+      mockPrismaProject.findMany.mockResolvedValue([]);
       mockPrismaProject.create.mockResolvedValue(created);
 
       const result = await service.create(dto);
 
-      expect(mockPrismaProject.create).toHaveBeenCalledWith({ data: dto });
+      expect(mockPrismaProject.create).toHaveBeenCalledWith({
+        data: { ...dto, slug: 'minimal-project' },
+      });
       expect(result).toEqual(created);
     });
   });
@@ -70,8 +76,8 @@ describe('ProjectsService', () => {
   describe('findAll', () => {
     it('should return all projects', async () => {
       const projects = [
-        { id: 'proj-1', name: 'Project A', description: null, createdAt: new Date() },
-        { id: 'proj-2', name: 'Project B', description: 'Desc', createdAt: new Date() },
+        { id: 'proj-1', name: 'Project A', slug: 'project-a', description: null, createdAt: new Date() },
+        { id: 'proj-2', name: 'Project B', slug: 'project-b', description: 'Desc', createdAt: new Date() },
       ];
       mockPrismaProject.findMany.mockResolvedValue(projects);
 
@@ -84,7 +90,7 @@ describe('ProjectsService', () => {
 
   describe('findOne', () => {
     it('should return a project when found', async () => {
-      const project = { id: 'proj-1', name: 'Project A', description: null, createdAt: new Date() };
+      const project = { id: 'proj-1', name: 'Project A', slug: 'project-a', description: null, createdAt: new Date() };
       mockPrismaProject.findUnique.mockResolvedValue(project);
 
       const result = await service.findOne('proj-1');
@@ -103,13 +109,29 @@ describe('ProjectsService', () => {
   });
 
   describe('update', () => {
-    it('should update a project and return it', async () => {
+    it('should update a project and return it with a new slug', async () => {
       const dto = { name: 'Updated Name' };
-      const updated = { id: 'proj-1', name: 'Updated Name', description: null, createdAt: new Date() };
+      const updated = { id: 'proj-1', name: 'Updated Name', slug: 'updated-name', description: null, createdAt: new Date() };
+      mockPrismaProject.findMany.mockResolvedValue([]);
       mockPrismaProject.update.mockResolvedValue(updated);
 
       const result = await service.update('proj-1', dto);
 
+      expect(mockPrismaProject.update).toHaveBeenCalledWith({
+        where: { id: 'proj-1' },
+        data: { ...dto, slug: 'updated-name' },
+      });
+      expect(result).toEqual(updated);
+    });
+
+    it('should update a project without name change (no slug regen needed)', async () => {
+      const dto = { description: 'New description' };
+      const updated = { id: 'proj-1', name: 'Alpha', slug: 'alpha', description: 'New description', createdAt: new Date() };
+      mockPrismaProject.update.mockResolvedValue(updated);
+
+      const result = await service.update('proj-1', dto);
+
+      expect(mockPrismaProject.findMany).not.toHaveBeenCalled();
       expect(mockPrismaProject.update).toHaveBeenCalledWith({
         where: { id: 'proj-1' },
         data: dto,
@@ -123,6 +145,7 @@ describe('ProjectsService', () => {
         'Record not found',
         { code: 'P2025', clientVersion: '5.0.0' },
       );
+      mockPrismaProject.findMany.mockResolvedValue([]);
       mockPrismaProject.update.mockRejectedValue(p2025Error);
 
       await expect(service.update('nonexistent-id', dto)).rejects.toThrow(NotFoundException);
@@ -132,7 +155,7 @@ describe('ProjectsService', () => {
 
   describe('remove', () => {
     it('should delete a project and return it', async () => {
-      const deleted = { id: 'proj-1', name: 'Project A', description: null, createdAt: new Date() };
+      const deleted = { id: 'proj-1', name: 'Project A', slug: 'project-a', description: null, createdAt: new Date() };
       mockPrismaProject.delete.mockResolvedValue(deleted);
 
       const result = await service.remove('proj-1');
@@ -150,6 +173,105 @@ describe('ProjectsService', () => {
 
       await expect(service.remove('nonexistent-id')).rejects.toThrow(NotFoundException);
       await expect(service.remove('nonexistent-id')).rejects.toThrow('Project not found');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // slugify (private — tested indirectly via generateUniqueSlug)
+  // -----------------------------------------------------------------------
+
+  describe('slugify (via generateUniqueSlug)', () => {
+    beforeEach(() => {
+      mockPrismaProject.findMany.mockResolvedValue([]);
+    });
+
+    it('converts spaces and uppercase to lowercase-hyphenated', async () => {
+      const slug = await service.generateUniqueSlug('My Project');
+      expect(slug).toBe('my-project');
+    });
+
+    it('strips accents (NFKD normalize)', async () => {
+      const slug = await service.generateUniqueSlug('Café Açaí');
+      expect(slug).toBe('cafe-acai');
+    });
+
+    it('normalizes special characters: "Hello, World! (2024)" → "hello-world-2024"', async () => {
+      const slug = await service.generateUniqueSlug('Hello, World! (2024)');
+      expect(slug).toBe('hello-world-2024');
+    });
+
+    it('trims leading and trailing hyphens', async () => {
+      const slug = await service.generateUniqueSlug('  --test--  ');
+      expect(slug).toBe('test');
+    });
+
+    it('falls back to "project" for empty/no-alnum input', async () => {
+      const slug = await service.generateUniqueSlug('!!!');
+      expect(slug).toBe('project');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // generateUniqueSlug — collision resolution
+  // -----------------------------------------------------------------------
+
+  describe('generateUniqueSlug', () => {
+    it('returns base slug when no collision', async () => {
+      mockPrismaProject.findMany.mockResolvedValue([]);
+      const slug = await service.generateUniqueSlug('My Project');
+      expect(slug).toBe('my-project');
+    });
+
+    it('appends -2 when base slug already exists', async () => {
+      mockPrismaProject.findMany.mockResolvedValue([{ slug: 'my-project' }]);
+      const slug = await service.generateUniqueSlug('My Project');
+      expect(slug).toBe('my-project-2');
+    });
+
+    it('appends -3 when base and -2 already exist (third collision)', async () => {
+      mockPrismaProject.findMany.mockResolvedValue([
+        { slug: 'my-project' },
+        { slug: 'my-project-2' },
+      ]);
+      const slug = await service.generateUniqueSlug('My Project');
+      expect(slug).toBe('my-project-3');
+    });
+
+    it('excludes current project id on rename so slug is preserved when name unchanged', async () => {
+      // Only one project with slug 'alpha' (the one being renamed), so no collision
+      mockPrismaProject.findMany.mockResolvedValue([]);
+      const slug = await service.generateUniqueSlug('Alpha', 'proj-1');
+      expect(slug).toBe('alpha');
+    });
+
+    it('rename with collision gets -2', async () => {
+      // Another project already owns 'beta'
+      mockPrismaProject.findMany.mockResolvedValue([{ slug: 'beta' }]);
+      const slug = await service.generateUniqueSlug('Beta', 'proj-2');
+      expect(slug).toBe('beta-2');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // findBySlug
+  // -----------------------------------------------------------------------
+
+  describe('findBySlug', () => {
+    it('returns the project when slug matches', async () => {
+      const project = { id: 'proj-1', name: 'My Project', slug: 'my-project', description: null, createdAt: new Date() };
+      mockPrismaProject.findUnique.mockResolvedValue(project);
+
+      const result = await service.findBySlug('my-project');
+
+      expect(mockPrismaProject.findUnique).toHaveBeenCalledWith({ where: { slug: 'my-project' } });
+      expect(result).toEqual(project);
+    });
+
+    it('throws NotFoundException when slug does not exist', async () => {
+      mockPrismaProject.findUnique.mockResolvedValue(null);
+
+      await expect(service.findBySlug('unknown')).rejects.toThrow(NotFoundException);
+      await expect(service.findBySlug('unknown')).rejects.toThrow('Project not found');
     });
   });
 });

--- a/apps/api/src/projects/projects.service.ts
+++ b/apps/api/src/projects/projects.service.ts
@@ -8,8 +8,83 @@ import { Prisma } from '@prisma/client';
 export class ProjectsService {
   constructor(private readonly prisma: PrismaService) {}
 
-  create(dto: CreateProjectDto) {
-    return this.prisma.project.create({ data: dto });
+  // ---------------------------------------------------------------------------
+  // Slug utilities
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Converts a project name to a URL-safe slug:
+   * - NFKD normalize to strip accents
+   * - lowercase + trim
+   * - replace runs of non-alphanumeric chars with a hyphen
+   * - strip leading/trailing hyphens
+   * - fall back to 'project' when the result is empty
+   */
+  private slugify(name: string): string {
+    return (
+      name
+        .normalize('NFKD')
+        .replace(/[̀-ͯ]/g, '') // strip combining diacritics
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9]+/g, '-') // non-alnum runs → hyphen
+        .replace(/^-+|-+$/g, '') // trim leading/trailing hyphens
+      || 'project'
+    );
+  }
+
+  /**
+   * Returns a unique slug derived from `name`.
+   * Queries existing slugs with the same base and picks the next free suffix.
+   * On rename, pass `excludeId` to ignore the current project's own slug.
+   */
+  async generateUniqueSlug(name: string, excludeId?: string): Promise<string> {
+    const base = this.slugify(name);
+
+    const existing = await this.prisma.project.findMany({
+      where: {
+        slug: { startsWith: base },
+        ...(excludeId ? { id: { not: excludeId } } : {}),
+      },
+      select: { slug: true },
+    });
+
+    const slugSet = new Set(existing.map((p) => p.slug));
+
+    if (!slugSet.has(base)) {
+      return base;
+    }
+
+    const suffix = this.computeNextSuffix(base, slugSet);
+    return `${base}-${suffix}`;
+  }
+
+  /**
+   * Finds the highest numeric suffix among slugs matching `base` or `base-N`,
+   * then returns max + 1 (minimum 2, so the first duplicate becomes `base-2`).
+   */
+  private computeNextSuffix(base: string, slugSet: Set<string>): number {
+    const pattern = new RegExp(`^${base}-(\\d+)$`);
+    let max = 1;
+
+    for (const slug of slugSet) {
+      const match = pattern.exec(slug);
+      if (match) {
+        const n = parseInt(match[1], 10);
+        if (n > max) max = n;
+      }
+    }
+
+    return max + 1;
+  }
+
+  // ---------------------------------------------------------------------------
+  // CRUD
+  // ---------------------------------------------------------------------------
+
+  async create(dto: CreateProjectDto) {
+    const slug = await this.generateUniqueSlug(dto.name);
+    return this.prisma.project.create({ data: { ...dto, slug } });
   }
 
   findAll() {
@@ -20,9 +95,21 @@ export class ProjectsService {
     return this.prisma.project.findUnique({ where: { id } });
   }
 
+  async findBySlug(slug: string) {
+    const project = await this.prisma.project.findUnique({ where: { slug } });
+    if (!project) throw new NotFoundException('Project not found');
+    return project;
+  }
+
   async update(id: string, dto: UpdateProjectDto) {
     try {
-      return await this.prisma.project.update({ where: { id }, data: dto });
+      const data: typeof dto & { slug?: string } = { ...dto };
+
+      if (dto.name !== undefined) {
+        data.slug = await this.generateUniqueSlug(dto.name, id);
+      }
+
+      return await this.prisma.project.update({ where: { id }, data });
     } catch (e) {
       if (
         e instanceof Prisma.PrismaClientKnownRequestError &&

--- a/apps/api/test/tasks.e2e-spec.ts
+++ b/apps/api/test/tasks.e2e-spec.ts
@@ -24,7 +24,7 @@ describe('TasksController (e2e)', () => {
   beforeEach(async () => {
     await prisma.task.deleteMany({});
     await prisma.project.deleteMany({});
-    const project = await prisma.project.create({ data: { name: 'Test Project' } });
+    const project = await prisma.project.create({ data: { name: 'Test Project', slug: 'test-project' } });
     projectId = project.id;
   });
 

--- a/apps/web/src/app/board/[slug]/page.tsx
+++ b/apps/web/src/app/board/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import { cookies } from 'next/headers'
-import { redirect, notFound } from 'next/navigation'
+import { notFound } from 'next/navigation'
 import type { Task, Project, User } from '@mantys/types'
 import KanbanBoard from '@/components/board/KanbanBoard'
 import Sidebar from '@/components/board/Sidebar'
@@ -20,34 +20,28 @@ async function fetchWithAuth<T>(path: string, token: string): Promise<T> {
   return res.json()
 }
 
-export default async function BoardPage({
-  searchParams,
+export default async function BoardSlugPage({
+  params,
 }: {
-  searchParams: { projectId?: string }
+  params: { slug: string }
 }) {
   const token = cookies().get('auth-token')?.value ?? ''
-  const { projectId } = searchParams
+  const { slug } = params
 
-  // Legacy redirect: /board?projectId=<cuid> → /board/<slug>
-  if (projectId) {
-    let project: Project
-    try {
-      project = await fetchWithAuth<Project>(`/projects/${projectId}`, token)
-    } catch {
-      notFound()
-    }
-    redirect(`/board/${project!.slug}`)
+  // Resolve slug → project (404 if slug unknown)
+  let project: Project
+  try {
+    project = await fetchWithAuth<Project>(`/projects/by-slug/${slug}`, token)
+  } catch {
+    notFound()
   }
 
-  // All-projects view
   const [tasks, projects, users, profile] = await Promise.all([
-    fetchWithAuth<Task[]>('/tasks', token),
+    fetchWithAuth<Task[]>(`/tasks?projectId=${project!.id}`, token),
     fetchWithAuth<Project[]>('/projects', token),
     fetchWithAuth<User[]>('/users', token),
     fetchWithAuth<JwtProfile>('/auth/profile', token).catch(() => null),
   ])
-
-  if (projects.length === 0) redirect('/projects/new')
 
   const foundUser = profile ? users.find((u) => u.id === profile.id) : undefined
   const currentUser = profile
@@ -58,13 +52,14 @@ export default async function BoardPage({
 
   return (
     <div className="flex h-screen bg-[#0d0d0f]">
-      <Sidebar projects={projects} currentUserRole={profile?.role} />
+      <Sidebar projects={projects} activeProjectSlug={slug} currentUserRole={profile?.role} />
       <KanbanBoard
-        key="all"
+        key={project!.id}
         initialTasks={tasks}
         projects={projects}
         users={users}
         currentUser={currentUser}
+        activeProjectId={project!.id}
       />
     </div>
   )

--- a/apps/web/src/app/board/page.tsx
+++ b/apps/web/src/app/board/page.tsx
@@ -1,5 +1,5 @@
 import { cookies } from 'next/headers'
-import { redirect, notFound } from 'next/navigation'
+import { redirect, permanentRedirect, notFound } from 'next/navigation'
 import type { Task, Project, User } from '@mantys/types'
 import KanbanBoard from '@/components/board/KanbanBoard'
 import Sidebar from '@/components/board/Sidebar'
@@ -36,7 +36,7 @@ export default async function BoardPage({
     } catch {
       notFound()
     }
-    redirect(`/board/${project!.slug}`)
+    permanentRedirect(`/board/${project!.slug}`)
   }
 
   // All-projects view

--- a/apps/web/src/components/board/Sidebar.tsx
+++ b/apps/web/src/components/board/Sidebar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, usePathname } from 'next/navigation'
 import Link from 'next/link'
 import type { Project } from '@mantys/types'
 import { cn } from '@/lib/utils'
@@ -9,17 +9,23 @@ import ProjectModal from './ProjectModal'
 
 interface Props {
   projects: Project[]
-  activeProjectId?: string
+  /** Slug of the currently active project, if any. */
+  activeProjectSlug?: string
   currentUserRole?: string
 }
 
-export default function Sidebar({ projects: initialProjects, activeProjectId, currentUserRole }: Props) {
+export default function Sidebar({ projects: initialProjects, activeProjectSlug, currentUserRole }: Props) {
   const router = useRouter()
+  const pathname = usePathname()
   const [projects, setProjects] = useState<Project[]>(initialProjects)
   const [modal, setModal] = useState<{ open: boolean; mode: 'create' | 'edit'; project?: Project }>({
     open: false,
     mode: 'create',
   })
+
+  // Derive active slug from URL path when not passed explicitly.
+  // Path shape: /board/<slug>  → segments[2] = slug
+  const currentSlug = activeProjectSlug ?? pathname.split('/')[2] ?? undefined
 
   function openCreate() {
     setModal({ open: true, mode: 'create' })
@@ -36,17 +42,18 @@ export default function Sidebar({ projects: initialProjects, activeProjectId, cu
     })
     setModal({ open: false, mode: 'create' })
     if (modal.mode === 'create') {
-      router.push(`/board?projectId=${saved.id}`)
+      router.push(`/board/${saved.slug}`)
     }
   }
 
   function handleDelete(projectId: string) {
     const remaining = projects.filter((p) => p.id !== projectId)
+    const deletedProject = projects.find((p) => p.id === projectId)
     setProjects(remaining)
     setModal({ open: false, mode: 'create' })
     if (remaining.length === 0) {
       router.push('/projects/new')
-    } else if (activeProjectId === projectId) {
+    } else if (currentSlug === deletedProject?.slug) {
       router.push('/board')
     }
   }
@@ -69,7 +76,7 @@ export default function Sidebar({ projects: initialProjects, activeProjectId, cu
             href="/board"
             className={cn(
               'flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors',
-              !activeProjectId
+              !currentSlug
                 ? 'bg-[#18181c] text-[#e4e4e7]'
                 : 'text-[#a1a1aa] hover:bg-[#18181c] hover:text-[#e4e4e7]',
             )}
@@ -79,10 +86,10 @@ export default function Sidebar({ projects: initialProjects, activeProjectId, cu
           {projects.map((p) => (
             <div key={p.id} className="group relative mt-0.5">
               <Link
-                href={`/board?projectId=${p.id}`}
+                href={`/board/${p.slug}`}
                 className={cn(
                   'flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors pr-8',
-                  activeProjectId === p.id
+                  currentSlug === p.slug
                     ? 'bg-[#18181c] text-[#e4e4e7]'
                     : 'text-[#a1a1aa] hover:bg-[#18181c] hover:text-[#e4e4e7]',
                 )}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -33,6 +33,7 @@ export interface User {
 export interface Project {
   id: string;
   name: string;
+  slug: string;
   description?: string;
   createdAt: Date;
 }


### PR DESCRIPTION
Closes #50

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Adds `slug` field to the `Project` model (Prisma), auto-generated from the project name using pure-JS slugify with collision resolution
- New API endpoint `GET /projects/by-slug/:slug` and Next.js dynamic route `/board/[slug]` replace the CUID-based board URL
- Legacy `?projectId=<cuid>` URLs redirect to `/board/<slug>` via `permanentRedirect()` (308)

## Changes

| File | Change |
|------|--------|
| `apps/api/prisma/schema.prisma` | Add `slug String @unique` to `Project` model |
| `apps/api/prisma/migrations/20260614120000_add_project_slug/migration.sql` | 4-step safe migration: nullable → backfill → NOT NULL → UNIQUE INDEX |
| `apps/api/src/projects/projects.service.ts` | Add `slugify()`, `generateUniqueSlug()`, `findBySlug()`, generate slug on create |
| `apps/api/src/projects/projects.controller.ts` | Add `GET /projects/by-slug/:slug` before `GET /:id` |
| `apps/api/src/projects/projects.service.spec.ts` | Unit tests for slug generation and findBySlug (TDD) |
| `packages/types/src/index.ts` | Add `slug: string` to `Project` interface |
| `apps/web/src/app/board/[slug]/page.tsx` | New dynamic board route resolved by slug |
| `apps/web/src/app/board/page.tsx` | Detect `?projectId=` and `permanentRedirect()` to `/board/<slug>` |
| `apps/web/src/components/board/Sidebar.tsx` | Update board links to use slug |

## Test Plan

- [x] All 80 API tests pass (`cd apps/api && npm test --runInBand`)
- [x] Migration SQL verified: safe 4-step order, no `unaccent` extension dependency
- [x] `GET /projects/by-slug/:slug` declared before `GET /:id` (routing collision prevented)
- [x] Legacy redirect uses `permanentRedirect()` (308), not `redirect()` (307)
- [x] No external slugify library added

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers